### PR TITLE
Add support for digging into ansible fact hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+
+## 0.1.0
+
+* Added support for digging into hashes for assigning scope values with the dot notation
+
+### 0.0.1 initial release
+

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Once this plugin is installed, it can be used in Ansible playbooks by placing a 
 token: ansible:52cbf789c7837f9a4aef0d259c00d131f0f2a47894519c273c64a608de1382cba4221447752e9ac2
 scope:
   hostname: ansible_nodename
-  environment: environment
+  environment: ansible_local.custom.environment
   osfamily: ansible_os_family
 ```
 
@@ -58,7 +58,7 @@ Note that the scope keys in this example are the scope values used in the Jeraki
 Supported configuration parameters of `jerakia.yaml` are:
 
 * `token`: The Jerakia token to use to authenticate against Jerakia server, mandatory.
-* `scope`: A hash containing the scope to use for the request, the values will be resolved as Ansible facts
+* `scope`: A hash containing the scope to use for the request, the values will be resolved as Ansible facts.  Use a dot notation to dig deeper into nested hash facts (see `environment` above)
 * `protocol`: The URL protocol to use, default `http`
 * `host`: Hostname of the Jerakia Server, default `localhost`
 * `port`: Jerakia port to connect to, default `9843`


### PR DESCRIPTION

This adds the ability to use nested hash values in setting scope... For example, if you wish to use a custom fact which is nested under `ansible_local` you can now specify

```yaml
  scope:
    environment: ansible_local.custom.environment
```
