### PR TITLE
Make location of config file configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This is an ansible lookup plugin for integrating with Jerakia
 
 ### Jerakia
 
-[Jerakia](http://jerakia.io) is a hierarchical lookup tool.  It supports pluggable datasources and the ability to override values in the hierarchy using information about the requestor.  See [The official Jerakia site](http://jerakia.io) for more general information on Jerakia.
+[Jerakia](http://jerakia.io) is a hierarchical lookup tool. It supports pluggable datasources and the ability to override values in the hierarchy using information about the requestor. See [The official Jerakia site](http://jerakia.io) for more general information on Jerakia.
 
 ### Description
 
-This plugin provides an interface between Ansible and Jerakia by way of a [lookup plugin](http://docs.ansible.com/ansible/latest/playbooks_lookups.html).  Further plugin types are being investigated.
+This plugin provides an interface between Ansible and Jerakia by way of a [lookup plugin](http://docs.ansible.com/ansible/latest/playbooks_lookups.html). Further plugin types are being investigated.
 
-A hierarchical lookup is made by applying a _scope_ against a hierarchy of lookup paths.  A scope is simply information about the requestor, in this case the Ansible node, that it used in determining what data to return.  A scope could consist of anything, typical things would be the hostname, environment and location of the node.  Using the scope provided in the lookup, Jerakia will run through a hierarchy and return the relevant value.
+A hierarchical lookup is made by applying a _scope_ against a hierarchy of lookup paths. A scope is simply information about the requestor, in this case the Ansible node, that it used in determining what data to return. A scope could consist of anything, typical things would be the hostname, environment and location of the node. Using the scope provided in the lookup, Jerakia will run through a hierarchy and return the relevant value.
 
 For the examples in the next section, we assume that Jerakia Server is installed and running on it's default port on the local machine and that we have the following default policy configured in Jerakia
 
@@ -35,17 +35,13 @@ policy :default do
 end
 ```
 
-See [the official documentation](http://jerakia.io/basics/lookups/) for more information about Jerakia policies and lookups
+See [the official documentation](http://jerakia.io/basics/lookups/) for more information about Jerakia policies and lookups.
 
 ### Configuration
 
-
-Once this plugin is installed, it can be used in Ansible playbooks by placing a `jerakia.yaml` file in the directory where your playbook is located.  `jerakia.yaml` must contain an [authentication token](http://jerakia.io/server/tokens) to use to connect to Jerakia Server.  We can also use the `scope` hash to map Ansible variables (facts) to the scope values used by the Jerakia policy above, eg:
-
+The plugin will look for the `ANSIBLE_JERAKIA_CONFIG` environment variable to determine the location of the config file. If the variable is not set, it will look for a `jerakia.yaml` file in the directory where your playbook is located. The config file must contain an [authentication token](http://jerakia.io/server/tokens) to use to connect to Jerakia Server. We can also use the `scope` hash to map Ansible variables (facts) to the scope values used by the Jerakia policy above, eg:
 
 ```yaml
-# ./jerakia.yaml
-
 token: ansible:52cbf789c7837f9a4aef0d259c00d131f0f2a47894519c273c64a608de1382cba4221447752e9ac2
 scope:
   hostname: ansible_nodename
@@ -57,23 +53,24 @@ Note that the scope keys in this example are the scope values used in the Jeraki
 
 Supported configuration parameters of `jerakia.yaml` are:
 
-* `token`: The Jerakia token to use to authenticate against Jerakia server, mandatory.
-* `scope`: A hash containing the scope to use for the request, the values will be resolved as Ansible facts.  Use a dot notation to dig deeper into nested hash facts (see `environment` above)
-* `protocol`: The URL protocol to use, default `http`
-* `host`: Hostname of the Jerakia Server, default `localhost`
-* `port`: Jerakia port to connect to, default `9843`
-* `version`: Jerakia API version to use, default `1`
-* `policy`: Jerakia policy to use for the lookups, default `default`
-
+| Parameter | Description | Required | Default |
+|-----------|-------------|:--------:|:-------:|
+| `token`   | The Jerakia token to use to authenticate against Jerakia server | Yes | - |
+| `scope`   | A hash containing the scope to use for the request, the values will be resolved as Ansible facts. Use a dot notation to dig deeper into nested hash facts (see `environment` above) | No | - |
+| `protocol` | The URL protocol to use | No | `http` |
+| `host`    | Hostname of the Jerakia Server | No | `localhost` |
+| `port`    | Jerakia port to connect to | No | `9843` |
+| `version` | Jerakia API version to use | No | `1` |
+| `policy`  | Jerakia policy to use for the lookups | No | `default` |
 
 ### Usage
 
-Once configured with a jerakia.yaml, you can call the Jerakia lookup plugin directly from your playbooks using the `lookup` method.  The first argument is always the name of the plugin, `jerakia`, and the following arguments contain the namespace and key to lookup, which is formatted as `<namespace>/<key>`
+Once configured with a jerakia.yaml, you can call the Jerakia lookup plugin directly from your playbooks using the `lookup` method. The first argument is always the name of the plugin, `jerakia`, and the following arguments contain the namespace and key to lookup, which is formatted as `<namespace>/<key>`
 
 ```yaml
 - hosts: all
   tasks:
-    - debug: msg=" {{ lookup('jerakia',  'apache/port') }}"
+    - debug: msg=" {{ lookup('jerakia', 'apache/port') }}"
 ```
 
 In the above example, if we assume the value of `ansible_nodename` is `foo.enviatics.com`, `environment` is `dev` and `ansible_os_family` is `RedHat` then with the policy we have declared, this will cause Jerakia to look up the key `port` in the namespace `apache`, it will follow the following hierarchy of files looking for the key `port` and return the first value it finds:
@@ -83,7 +80,7 @@ In the above example, if we assume the value of `ansible_nodename` is `foo.envia
 * `/var/lib/jerakia/data/operating_system/RedHat/apache.yaml`
 * `/var/lib/jerakia/data/common/apache.yaml`
 
-So we would be able to define a default value for the Apache port in `common/apache.yaml` but then have the ability to override this value based on a specific node, environment or operating system type.  Note that the structure of the hierarchy here is purely an example, and is entirely configurable to suit your specific environment and needs.
+So we would be able to define a default value for the Apache port in `common/apache.yaml` but then have the ability to override this value based on a specific node, environment or operating system type. Note that the structure of the hierarchy here is purely an example, and is entirely configurable to suit your specific environment and needs.
 
 ### Contributing
 
@@ -93,10 +90,6 @@ This is a very new project so contributions are always welcome, please submit a 
 
 This project is maintained by Craig Dunn <craig@craigdunn.org> - @crayfishx
 
-
 ### License
 
-This project is licensed under the Apache 2.0 license, please the the LICENSE file included with this software
-
-
-
+This project is licensed under the Apache 2.0 license, please the the LICENSE file included with this software.

--- a/lib/ansible/plugins/lookup/jerakia.py
+++ b/lib/ansible/plugins/lookup/jerakia.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import yaml
-import os.path
-import requests
 import json
+import os
+import requests
+import yaml
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
@@ -41,7 +41,7 @@ class Jerakia(object):
             'policy': 'default'
         }
 
-    def get_config(self, configfile='jerakia.yaml'):
+    def get_config(self, configfile=os.environ.get('ANSIBLE_JERAKIA_CONFIG', 'jerakia.yaml')):
         defaults = self.config_defaults()
 
         if os.path.isfile(configfile):

--- a/lib/ansible/plugins/lookup/jerakia.py
+++ b/lib/ansible/plugins/lookup/jerakia.py
@@ -1,11 +1,11 @@
 # Copyright 2017 Craig Dunn <craig@craigdunn.org>
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,7 +17,7 @@ import os.path
 import requests
 import json
 
-from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
 try:
@@ -26,13 +26,14 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
+
 class Jerakia(object):
-    def __init__(self,base):
+    def __init__(self, base):
         self.base = base
         self.config = self.get_config()
 
     def config_defaults(self):
-        return { 
+        return {
             'protocol': 'http',
             'host': '127.0.0.1',
             'port': '9843',
@@ -56,21 +57,20 @@ class Jerakia(object):
         host = self.config['host']
         port = self.config['port']
         version = self.config['version']
-        url = "%(proto)s://%(host)s:%(port)s/v%(version)s/lookup/%(key)s" % locals() 
+        url = "%(proto)s://%(host)s:%(port)s/v%(version)s/lookup/%(key)s" % locals()
         return url
 
     def dot_to_dictval(self, dic, key):
-      key_arr = key.split('.')
-      this_key = key_arr.pop(0)
+        key_arr = key.split('.')
+        this_key = key_arr.pop(0)
 
-      if not this_key in dic:
-        raise AnsibleError("Cannot find key %s " % key)
+        if this_key not in dic:
+            raise AnsibleError("Cannot find key %s " % key)
 
-      if len(key_arr) == 0:
-        return dic[this_key]
+        if len(key_arr) == 0:
+            return dic[this_key]
 
-      return self.dot_to_dictval(dic[this_key], '.'.join(key_arr))
-
+        return self.dot_to_dictval(dic[this_key], '.'.join(key_arr))
 
     def scope(self, variables):
         scope_data = {}
@@ -83,8 +83,6 @@ class Jerakia(object):
             scope_data[metadata_entry] = scope_value
         return scope_data
 
-        
-
     def headers(self):
         token = self.config['token']
         if not token:
@@ -94,12 +92,11 @@ class Jerakia(object):
             'X-Authentication': token
         }
 
-
     def lookup(self, key, namespace, policy='default', variables=None):
         endpoint_url = self.lookup_endpoint_url(key=key)
         namespace_str = '/'.join(namespace)
         scope = self.scope(variables)
-        options = { 
+        options = {
             'namespace': namespace_str,
             'policy': policy,
         }
@@ -109,30 +106,27 @@ class Jerakia(object):
 
         response = requests.get(endpoint_url, params=params, headers=headers)
         if response.status_code == requests.codes.ok:
-          return json.loads(response.text)
+            return json.loads(response.text)
         else:
-          raise AnsibleError("Bad HTTP response")
+            raise AnsibleError("Bad HTTP response")
 
 
 # Entry point for Ansible starts here with the LookupModule class
 #
 class LookupModule(LookupBase):
-
     def run(self, terms, variables=None, **kwargs):
+        jerakia = Jerakia(self)
+        ret = []
 
-         jerakia = Jerakia(self)
-         ret = []
+        for term in terms:
+            lookuppath = term.split('/')
+            key = lookuppath.pop()
+            namespace = lookuppath
 
-         for term in terms:
-             lookuppath=term.split('/')
-             key = lookuppath.pop()
-             namespace = lookuppath
+            if not namespace:
+                raise AnsibleError("No namespace given for lookup of key %s" % key)
 
-             if not namespace:
-                 raise AnsibleError("No namespace given for lookup of key %s" % key)
+            response = jerakia.lookup(key=key, namespace=namespace, variables=variables)
+            ret.append(response['payload'])
 
-             response = jerakia.lookup(key=key, namespace=namespace, variables=variables)
-             ret.append(response['payload'])
-
-         return ret
-
+        return ret


### PR DESCRIPTION
Use an environment variable to configure the location of the config file and fall back to the `jerakia.yaml` in the playbook directory if the variable is not set.