### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/lib/ansible/plugins/lookup/jerakia.py
+++ b/lib/ansible/plugins/lookup/jerakia.py
@@ -47,7 +47,8 @@ class Jerakia(object):
         if os.path.isfile(configfile):
             data = open(configfile, "r")
             defined_config = yaml.load(data)
-            combined_config = dict(defaults.items() + defined_config.items())
+            combined_config = defaults.copy()
+            combined_config.update(defined_config)
             return combined_config
         else:
             raise AnsibleError("Unable to find configuration file %s" % configfile)
@@ -77,7 +78,7 @@ class Jerakia(object):
         scope_conf = self.config['scope']
         if not self.config['scope']:
             return {}
-        for key, val in scope_conf.iteritems():
+        for key, val in scope_conf.items():
             metadata_entry = "metadata_%(key)s" % locals()
             scope_value = self.dot_to_dictval(variables, val)
             scope_data[metadata_entry] = scope_value

--- a/lib/ansible/plugins/lookup/jerakia.py
+++ b/lib/ansible/plugins/lookup/jerakia.py
@@ -102,7 +102,8 @@ class Jerakia(object):
             'policy': policy,
         }
 
-        params = dict(scope.items() + options.items())
+        params = scope.copy()
+        params.update(options)
         headers = self.headers()
 
         response = requests.get(endpoint_url, params=params, headers=headers)


### PR DESCRIPTION
I tried to use this plugin with Python 3 and had to fix a few minor incompatibilities to make it work.

The `items()` call does return a copy instead of a generator in Python 2, but I think that's a fair compromise as the configuration is very unlikely to be large enough to cause a performance issue.

The dictionary merge could be written as `{**dict1, **dict2}` from Python 3.5 onward, which probably wouldn't be too much of a stretch as prerequisite as this point, but this would also break Python 2 compatibility.